### PR TITLE
Fix Invoke-PSInject for Windows 10 1803

### DIFF
--- a/Invoke-PSInject.ps1
+++ b/Invoke-PSInject.ps1
@@ -930,7 +930,7 @@ $RemoteScriptBlock = {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr


### PR DESCRIPTION
Fixes the "Ambiguous match found" error when using Invoke-PSInject on Win 10 1803.
Fixes #1
Tested on Windows 7, and Windows 10, builds 1709 and 1803.